### PR TITLE
Rewrite `step` and refactor `interpret`

### DIFF
--- a/phosphorus/phival.py
+++ b/phosphorus/phival.py
@@ -129,11 +129,8 @@ def step(x, n=1, accum=True, showrules=False, **kwargs):
     """
     # outputs is a list of sets
     # outputs[i] is the set of outputs after n steps
-    # if accum: keep all the steps around, but at each step only apply rules
-    #           to the previous step's outputs
-    # else:     only keep the last step around, since the earlier steps are irrelevant
     outputs = []
-    outputs.append(set([x])) # after 0 steps, x is the only output
+    outputs.append(set(ensurelist(x))) # after 0 steps, x is the only output
 
     for i in range(n):
         # for output printing, keep a dict of (input, rule) -> rule applied to input
@@ -145,24 +142,33 @@ def step(x, n=1, accum=True, showrules=False, **kwargs):
         newresults = dict(filter(lambda pair: pair[1] is not None, newresults.items()))
 
         if showrules:
+            from IPython.display import display_html
             if n > 1:
-                print(f"------\nStep {i + 1}\n------")
+                display_html(f"<span style='width:100%; border-bottom-style:solid; border-bottom-width:thin; display:inline-block; font-weight:bold;'>Step {i + 1}</span>", raw=True)
             for y,r in newresults:
-                print(f"Ran rule {r} on {y} to get {newresults[(y,r)]}.")
+                 display_html(f"<span style='float:right; font-family:monospace'>(by {r})</span>"
+                              f"<span>{y} &rightarrow; {newresults[(y,r)]}</span>", raw=True)
         
         newoutputs = set()
         for p in newresults:
-            newoutputs = newoutputs.union(newresults[p])
+            newoutputs.update(newresults[p])
         
+        # old steps are only needed if accumulating
         if not accum:
             outputs.pop(0)
         outputs.append(newoutputs)
 
+        # display current list of results
+        """ removed this to be consistent with showparse style in interpret
         if showrules:
             print(f"Current values: {set.union(*outputs) if accum else outputs[-1]}")
+        """
     
     # outputs is now a list of sets of outputs at each step
-    return list(set.union(*outputs))
+    final = []
+    for S in outputs:
+        final.extend(S)
+    return final
 
 def repeat(f,x,n,accum=False):
     """ Recursively applies f to x, n times.

--- a/phosphorus/phival.py
+++ b/phosphorus/phival.py
@@ -66,8 +66,8 @@ def interpret(x, showparse=None, memoize=True, **kwargs):
         # when memo is used, the parsing is never shown. So,
         # when parsing should be shown, memo is reset so that
         # everything gets computed by hand
-        if showparse and memoize != False:
-            memoize = dict()
+        if showparse and memoize:
+            memo = dict()
 
     # try/finally so that parseon state will always be reset at the end
     try:
@@ -120,7 +120,7 @@ def ensurelist(x):
     """
     return x if isinstance(x, (frozenset, set, list, tuple)) else [x]
 
-def step(x, n=1, accum=True, showrules=False, **kwargs):
+def step(x, n=1, accum=False, showrules=False, **kwargs):
     """ Similar to interpret, but for basic formal systems like MIU.
         Finds all outputs after applying rules to x at most n times.
         If accum == False: only finds outputs after exactly n rule applications
@@ -143,6 +143,8 @@ def step(x, n=1, accum=True, showrules=False, **kwargs):
 
         if showrules:
             from IPython.display import display_html
+            if n == 1:
+                display_html(f"<span style='width:100%; border-bottom-style:solid; border-bottom-width:thin; display:inline-block; font-weight:bold;'>Applying All Rules</span>", raw=True)
             if n > 1:
                 display_html(f"<span style='width:100%; border-bottom-style:solid; border-bottom-width:thin; display:inline-block; font-weight:bold;'>Step {i + 1}</span>", raw=True)
             for y,r in newresults:
@@ -179,26 +181,6 @@ def repeat(f,x,n,accum=False):
     for _ in range(n):
         x = ensurelist(x) + ensurelist(f(x)) if accum else f(x)
     return x
-
-def nstep(x, n=1, accum=True): 
-    """ DEPRECATED - step (above) is now able to apply rules many times,
-                     and should be used instead of nstep
-
-        Recursively applies all applicable rules to x, then the results
-        of those applications, and so on.
-        If accum == True:  returns a list of all results of all applications
-        If accum == False: returns a list of results of the final round of
-                           applications.
-    """
-    if not isinstance(x, (frozenset,set,list,tuple)):
-        x = [x]
-    x = list(x) #regularize
-    y = [a for b in x for a in interpret(b,multiple=True)]
-    if n > 1:
-        y = [a for a in step(y,n-1,accum)]
-    if accum:
-        y = x + y
-    return list(dict.fromkeys(y))
 
 class PhiVal(object):
     """ Base class for phosphorus objects """

--- a/phosphorus/phival.py
+++ b/phosphorus/phival.py
@@ -112,23 +112,43 @@ def interpret(x, showparse=None, multiple=False, memoize=True, **kwargs):
     return out[0]
 
 def ensurelist(x):
+    """ If x is not already a list or set, returns a list containing only x.
+        If x is already a list or set, returns x.
+    """
     if not isinstance(x, (frozenset,set,list,tuple)):
         x = [x]
     return x
     
 def step(x):
-    x = [a for b in ensurelist(x) for a in interpret(b,multiple=True)]
-    return list(dict.fromkeys(x))
+    """ Version of interpret for basic formal systems like MIU. Allows
+        multiple outputs, unlike a semantic interpretation function.
+        Applies all applicable rules to x then returns a list of the results.
+    """
+    x = ensurelist(x)
+    results = []
+    for y in x:
+        results.extend(interpret(y, multiple=True))
+    return list(set(results))
+    # x = [a for b in ensurelist(x) for a in interpret(b,multiple=True)]
+    # return list(dict.fromkeys(x))
 
 def repeat(f,x,n,accum=False):
+    """ Recursively applies f to x, n times.
+        If accum == False: returns the value of f(f(f(...f(x))))
+        If accum == True:  returns a list with each application:
+                           [x, f(x), f(f(x)), ..., f(f(f(...f(x))))]
+    """
     while n > 0:
         x = ensurelist(x) + f(x) if accum else f(x)
         n -= 1
     return x
 
 def nstep(x, n=1, accum=True): 
-    """ Version of interpret for basic formal systems like MIU. Allows
-        multiple outputs, unlike a semantic interpretation function.
+    """ Recursively applies all applicable rules to x, then the results
+        of those applications, and so on.
+        If accum == True:  returns a list of all results of all applications
+        If accum == False: returns a list of results of the final round of
+                           applications.
     """
     if not isinstance(x, (frozenset,set,list,tuple)):
         x = [x]


### PR DESCRIPTION
I ended up rewriting `step` to do everything on its own without calling `interpret`, and refactored `interpret` a bit with more documentation. `Step` now handles repetition (with/out accumulation) and showing which rules run at each step. `step` definitely got more complicated as a result, but to me it seems preferable to have these functions be separate since they need different things for printing messages along the way and optimizing memoization.

There's plenty of documentation in `step` now, and I added some for `interpret` and some related functions nearby. I did a bit of refactoring of `interpret` — it still does everything the same way, but I think I cleaned things up a little bit. I also slightly changed how the memoization works — now `memo` has nested dicts mapping {input : {binding : (output, rule used)}}, rather than {input : (binding, output, rule used)} like it was before. This is slightly more efficient because it's constant time to look up whether a binding has been seen before, but I doubt this makes a real difference.

I didn't implement memoization for `step`, but I can add it — it'll be a little more complicated than `interpret` but should still be doable. Honestly, I'm not sure it's necessary though, since the amount of output you'd need to be generating for it to make a real difference is massive (at least 9 generations of the MIU system, which is ~220k outputs).

Examples: [test-step.pdf](https://github.com/EasyArray/phosphorus/files/8074586/test-step.pdf)