### PR TITLE
Dark mode support

### DIFF
--- a/phosphorus/phival.py
+++ b/phosphorus/phival.py
@@ -178,9 +178,9 @@ class PhiVal(object):
         stype = SemType.type(self)
         if stype:
             stype = repr(stype).replace(' ', '')
-            out += ("<span style='float:right; font-family:monospace; font-weight:bold; background-color:#e7ffe5'>"
+            out += ("<span style='float:right; font-family:monospace; font-weight:bold; background-color:#e7ffe5; color:black;'>"
                     f"∈{stype}</span>")
-        out += ("<span style='float:right; font-family:monospace; font-weight:bold; background-color:#e5e5ff'>"
+        out += ("<span style='float:right; font-family:monospace; font-weight:bold; background-color:#e5e5ff; color:black;'>"
                 f"{self.type()}</span>")
         return out
             


### PR DESCRIPTION
Super quick change to force types to always be shown in black, since in a dark mode editor the text is default-white and difficult to read on light purple and green backgrounds. This resolves #19.