### PR TITLE
Add parens after lambda substitution during Span.update

### DIFF
--- a/phosphorus/parse.py
+++ b/phosphorus/parse.py
@@ -296,22 +296,21 @@ def totokens(s):
         prevend = tokeninfo.end
     
 def hasdelimiters(s):
-    """ Determine whether a string is wrapped in delimiters
-        s is a string
-    """
-    if not (s[0] in Token.delims and s[-1] == Token.delims[s[0]]):
+    """ Determine whether a string is wrapped in delimiters """
+    S = s if isinstance(s, str) else str(s)
+    if not (S[0] in Token.delims and S[-1] == Token.delims[S[0]]):
         return False
-    stack = [s[0]]
+    stack = [S[0]]
     curr = 0
     while stack:
         curr += 1
-        if curr == len(s):
-            raise SyntaxError(f"Unmatched delimiter: {stack[-1]} in {s}.")
-        if s[curr] in Token.delims:
-            stack.append(s[curr])
-        elif s[curr] == Token.delims[stack[-1]]:
+        if curr == len(S):
+            raise SyntaxError(f"Unmatched delimiter: {stack[-1]} in {S}.")
+        if S[curr] in Token.delims:
+            stack.append(S[curr])
+        elif S[curr] == Token.delims[stack[-1]]:
             stack.pop(-1)
-    return curr + 1 == len(s)
+    return curr + 1 == len(S)
 
 _debugging_contexts = dict()
 def debugging(context="", on = True):

--- a/phosphorus/parse.py
+++ b/phosphorus/parse.py
@@ -129,6 +129,8 @@ class Span(list):
                     if isinstance(peek, Span) and peek[0].string == "(":
                         peek = peek.update(subs) #apply bindings to args of lambda
                         item = item.sub({item.args[0] : peek.ev(False, False)}) #Basically run the func without checking types/domain restrictions
+                        if not hasdelimiters(str(item)):
+                            item = "(" + item + ")"
                         next(enum) #skip the arg
 
                 mylog("Finally" + str(item))
@@ -287,6 +289,24 @@ def totokens(s):
             except TokenError as e: pass #Ignore unclosed delimiters
         prevend = tokeninfo.end
     
+def hasdelimiters(s):
+    """ Determine whether a string is wrapped in delimiters
+        s is a string
+    """
+    if not (s[0] in Token.delims and s[-1] == Token.delims[s[0]]):
+        return False
+    stack = [s[0]]
+    curr = 0
+    while stack:
+        curr += 1
+        if curr == len(s):
+            raise SyntaxError(f"Unmatched delimiter: {stack[-1]} in {s}.")
+        if s[curr] in Token.delims:
+            stack.append(s[curr])
+        elif s[curr] == Token.delims[stack[-1]]:
+            stack.pop(-1)
+    return curr + 1 == len(s)
+
 _debugging_contexts = dict()
 def debugging(context="", on = True):
     global _debugging_contexts

--- a/phosphorus/parse.py
+++ b/phosphorus/parse.py
@@ -129,7 +129,13 @@ class Span(list):
                     if isinstance(peek, Span) and peek[0].string == "(":
                         peek = peek.update(subs) #apply bindings to args of lambda
                         item = item.sub({item.args[0] : peek.ev(False, False)}) #Basically run the func without checking types/domain restrictions
-                        if not hasdelimiters(str(item)):
+                        outerParens = ( # check for surrounding delimiters in self
+                            self[n - 1].string in Token.delims and
+                            len(self) > n + 2 and
+                            self[n + 2].string == Token.delims[self[n - 1].string]
+                        )
+                        if not (outerParens or hasdelimiters(item)):
+                            # add surrounding parens if needed
                             item = "(" + item + ")"
                         next(enum) #skip the arg
 

--- a/phosphorus/parse.py
+++ b/phosphorus/parse.py
@@ -118,12 +118,11 @@ class Span(list):
                             len(self) > n + 1 and
                             self[n + 1].string == Token.delims[self[n - 1].string]
                     )
-                    onlyItem = len(self) == 2 and n == 0 # check if lambda call is the only thing in self
-                    singleItem = len(item) == 1 # if item is something like 'x', it doesn't need parens
-                    if not (outerParens or onlyItem or singleItem or hasdelimiters(s)):
+                    onlyItem = len(self) == 2 and n == 0 # check if result of substitution is the only thing in self
+                    # if len == 1, then there is only one token in item, so parens aren't needed
+                    if not (outerParens or onlyItem or len(item) == 1):
                         # add surrounding parens if needed
-                        s = "(" + s + ")"
-                    item = Span.parse(spaces + s)
+                        item = Span.parse(spaces + "(" + s + ")")
                     mylog(f"Parsed: |{item}|")
                     if item.printlen() == 1: item = item[0]
             
@@ -147,8 +146,8 @@ class Span(list):
                             self[n + 2].string == Token.delims[self[n - 1].string]
                         )
                         onlyItem = len(self) == 2 and n == 0 # check if lambda call is the only thing in self
-                        singleItem = len(Span.parse(item)) == 1 # if item is something like 'x', it doesn't need parens
-                        if not (outerParens or onlyItem or singleItem or hasdelimiters(item)):
+                        # if len == 1, then there is only one token in item, so parens aren't needed
+                        if not (outerParens or onlyItem or len(Span.parse(item)) == 1):
                             # add surrounding parens if needed
                             item = "(" + item + ")"
                         next(enum) #skip the arg
@@ -308,23 +307,6 @@ def totokens(s):
             try: yield from totokens(repl)
             except TokenError as e: pass #Ignore unclosed delimiters
         prevend = tokeninfo.end
-    
-def hasdelimiters(s):
-    """ Determine whether a string is wrapped in delimiters """
-    S = s if isinstance(s, str) else str(s)
-    if not (S[0] in Token.delims and S[-1] == Token.delims[S[0]]):
-        return False
-    stack = [S[0]]
-    curr = 0
-    while stack:
-        curr += 1
-        if curr == len(S):
-            raise SyntaxError(f"Unmatched delimiter: {stack[-1]} in {S}.")
-        if S[curr] in Token.delims:
-            stack.append(S[curr])
-        elif S[curr] == Token.delims[stack[-1]]:
-            stack.pop(-1)
-    return curr + 1 == len(S)
 
 _debugging_contexts = dict()
 def debugging(context="", on = True):

--- a/phosphorus/parse.py
+++ b/phosphorus/parse.py
@@ -112,6 +112,18 @@ class Span(list):
                     s = str(item) #Problem if we want to use keywords as ConstantVals?
                     mylog(f"|{item}| transforms to |{s}|")
                     item = Span.parse(spaces + s)
+                    # logic for add parens if necessary
+                    outerParens = ( # check for surrounding delimiters in self
+                            self[n - 1].string in Token.delims and
+                            len(self) > n + 1 and
+                            self[n + 1].string == Token.delims[self[n - 1].string]
+                    )
+                    onlyItem = len(self) == 2 and n == 0 # check if lambda call is the only thing in self
+                    singleItem = len(item) == 1 # if item is something like 'x', it doesn't need parens
+                    if not (outerParens or onlyItem or singleItem or hasdelimiters(s)):
+                        # add surrounding parens if needed
+                        s = "(" + s + ")"
+                    item = Span.parse(spaces + s)
                     mylog(f"Parsed: |{item}|")
                     if item.printlen() == 1: item = item[0]
             
@@ -134,7 +146,9 @@ class Span(list):
                             len(self) > n + 2 and
                             self[n + 2].string == Token.delims[self[n - 1].string]
                         )
-                        if not (outerParens or hasdelimiters(item)):
+                        onlyItem = len(self) == 2 and n == 0 # check if lambda call is the only thing in self
+                        singleItem = len(Span.parse(item)) == 1 # if item is something like 'x', it doesn't need parens
+                        if not (outerParens or onlyItem or singleItem or hasdelimiters(item)):
                             # add surrounding parens if needed
                             item = "(" + item + ")"
                         next(enum) #skip the arg


### PR DESCRIPTION
This should resolve #32. Added a function to check whether a string is wrapped it parentheses. Then, during `Span.update`, used this after a &beta;-reduction to check whether the result needs to be wrapped in parens; if so, add the parens.

This results in extra parens when the result is already wrapped in parens, so for example

```py
[λf . [λx . (f(x)) * 2]]([λx . x + 3])
```

produces

```py
[λx∈e. (( x + 3)) * 2]
```

However, I think it's a bit unnatural to write something like `(f(x))`, and it doesn't seem like a huge problem to get extra parens. I think I could address this by doing some more checking in `Span.update`, but it seems like it would be a bit tricky given the setup.