### PR TITLE
Capture Avoiding Substitution

### DIFF
--- a/phosphorus/parse.py
+++ b/phosphorus/parse.py
@@ -60,6 +60,10 @@ class Span(list):
     def semtype(self):
         from .phival import ConstantVal
         return ConstantVal("t")
+
+    def variables(self):
+        """ returns set of all variables/names that appear in self, as strings """
+        return {str(item) for item in self.leaves() if item.type == NAME}
     
     def __bool__(self): raise NotImplementedError
     


### PR DESCRIPTION
When simplifying lambda calls, perform capture avoiding substitution as outlined in detail in a [comment](https://github.com/EasyArray/phosphorus/issues/21#issuecomment-1069366900) on #21.